### PR TITLE
PR: Change the location of the states cache

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -23,7 +23,7 @@ export function createElement<P extends Obj, T extends VNodeType<P>>(type: T, pr
 	return { type, props, children }
 }
 
-const _stateCache = (global as any).__SOMATIC_CACHE__ as any //Obj<Obj>
+const _stateCache: Obj<Obj> = (global as any).__SOMATIC_CACHE__ = {}
 
 /** Render virtual node to DOM node */
 export async function render<Props extends Obj, State>(vnode?: Primitive | Object | VNode<PropsExtended<Props, Message>> | Promise<VNode<PropsExtended<Props, Message>>>, parentKey?: string): Promise<Node> {

--- a/src/core.ts
+++ b/src/core.ts
@@ -23,7 +23,7 @@ export function createElement<P extends Obj, T extends VNodeType<P>>(type: T, pr
 	return { type, props, children }
 }
 
-const _stateCache = global as any //Obj<Obj>
+const _stateCache = (global as any).__SOMATIC_CACHE__ as any //Obj<Obj>
 
 /** Render virtual node to DOM node */
 export async function render<Props extends Obj, State>(vnode?: Primitive | Object | VNode<PropsExtended<Props, Message>> | Promise<VNode<PropsExtended<Props, Message>>>, parentKey?: string): Promise<Node> {


### PR DESCRIPTION
Resolves #54 

**Merge message:**
Set the cache to be located in `global.__SOMATIC_CACHE__` instead of the global root, making it easier to find all cache entries.