### PR TITLE
PR: Fix problem with morphdom and ids

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
 		"@sparkwave/standard": "^2.23.0",
 		"cuid": "^2.1.8",
 		"fast-memoize": "^2.5.2",
-		"hash-sum": "^2.0.0",
 		"morphdom": "^2.6.1"
 	},
 	"devDependencies": {

--- a/src/core.ts
+++ b/src/core.ts
@@ -9,11 +9,10 @@
 
 import morphdom from 'morphdom'
 import fastMemoize from 'fast-memoize'
-import { default as hash } from 'hash-sum'
 import { VNode, VNodeType, PropsExtended, Message, MergedPropsExt, CSSProperties, ComponentExtended } from "./types"
 import { setAttribute, isEventKey, camelCaseToDash, encodeHTML, idProvider } from "./utils"
 import { svgTags, eventNames, mouseMvmntEventNames, } from "./constants"
-import { Obj, Primitive, flatten, deepMerge, hasValue } from "@sparkwave/standard"
+import { Obj, Primitive, flatten, deepMerge } from "@sparkwave/standard"
 
 // export const Fragment = (async () => ({})) as Renderer
 export const fnStore: ((evt: Event) => unknown)[] = []

--- a/src/core.ts
+++ b/src/core.ts
@@ -262,7 +262,7 @@ export function hydrate(element: HTMLElement): void {
  * @param rootElement An HTML element that will be updated
  * @param node A node obtained by rendering a VNode
  */
-export function updateDOM(rootElement: Element, node: Node) { morphdom(rootElement, node) }
+export function updateDOM(rootElement: Element, node: Node) { morphdom(rootElement, node, { getNodeKey: () => undefined }) }
 
 /** Global dictionary of events indexed by their names e.g., onmouseenter */
 const _eventHandlers: Obj<{ node: Node, handler: (e: Event) => void, capture: boolean }[]> = {}


### PR DESCRIPTION
Resolves #57 

**Merge message:**
Forced morphdom to treat HTML `id` attributes the same as any other attributes, by passing `{ getNodeKey: () => undefined }` as an argument of the `morphdom` function. It prevents DOM elements with an id from being wrongly kept intact when they actually changed and should have been morphed.