### PR TITLE
PR: Automatically publish to NPM on PR merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+ on:
+   push:
+     branches:
+       - master
+ name: release-please
+ jobs:
+   release-please:
+     runs-on: ubuntu-latest
+     steps:
+       - uses: GoogleCloudPlatform/release-please-action@v2
+         id: release
+         with:
+           token: ${{ secrets.GITHUB_TOKEN }}
+           release-type: node
+           package-name: standard
+           pull-request-title-pattern: "PR${scope}: release${component} ${version}"
+       - uses: actions/checkout@v2
+         if: ${{ steps.release.outputs.release_created }}
+       - uses: actions/setup-node@v1
+         with:
+           node-version: 12
+           registry-url: 'https://registry.npmjs.org'
+         if: ${{ steps.release.outputs.release_created }}
+       - run: npm ci
+         if: ${{ steps.release.outputs.release_created }}
+       - run: npm publish
+         env:
+           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+         if: ${{ steps.release.outputs.release_created }} 


### PR DESCRIPTION
Closes #61 

Used "Release Please" action to create a release PR after merging features on master. Later, that PR can be merged to create a release on GitHub and publish to NPM automatically.