### PR TITLE
PR: Rendering fixes

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -194,7 +194,8 @@ export const booleanAttributes = [
 	"DISABLED",
 	"CHECKED",
 	"READONLY",
-	"AUTOFOCUS"
+	"AUTOFOCUS",
+	"SELECTED"
 ]
 
 /** Attribute name conversions when passed to DOM setAttribute or rendered as HTML

--- a/src/core.ts
+++ b/src/core.ts
@@ -239,6 +239,7 @@ export async function updateChildrenAsync(eltDOM: DOMElement | DocumentFragment,
 		return updated
 	}))
 
+	// eslint-disable-next-line require-atomic-updates
 	eltDOM.textContent = ""
 	newChildren.forEach(child => {
 		eltDOM.append(child)

--- a/src/core.ts
+++ b/src/core.ts
@@ -246,14 +246,12 @@ export async function updateChildrenAsync(eltDOM: DOMElement | DocumentFragment,
         // fragment.append(...newChildren);
         // eltDOM.replaceChildren(fragment);
 
-        eltDOM.replaceChildren("")
+        eltDOM.replaceChildren()
         newChildren.forEach(child => {
             eltDOM.append(child)
-        });
+        })
         // eltDOM.appendChild(fragment);
         // eltDOM.append(fragment);
-
-
 	return eltDOM
 }
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -239,7 +239,7 @@ export async function updateChildrenAsync(eltDOM: DOMElement | DocumentFragment,
 		return updated
 	}))
 
-	eltDOM.replaceChildren("")
+	eltDOM.textContent = ""
 	newChildren.forEach(child => {
 		eltDOM.append(child)
 	})

--- a/src/core.ts
+++ b/src/core.ts
@@ -241,9 +241,7 @@ export async function updateChildrenAsync(eltDOM: DOMElement | DocumentFragment,
 		return updated
 	}))
 
-	const fragment = new DocumentFragment()
-	fragment.append(...newChildren)
-	eltDOM.replaceChildren(fragment)
+    newChildren.forEach(child => eltDOM.appendChild(child))
 
 	return eltDOM
 }

--- a/src/core.ts
+++ b/src/core.ts
@@ -239,7 +239,7 @@ export async function updateChildrenAsync(eltDOM: DOMElement | DocumentFragment,
 		return updated
 	}))
 
-	eltDOM.replaceChildren()
+	eltDOM.replaceChildren("")
 	newChildren.forEach(child => {
 		eltDOM.append(child)
 	})

--- a/src/core.ts
+++ b/src/core.ts
@@ -242,6 +242,17 @@ export async function updateChildrenAsync(eltDOM: DOMElement | DocumentFragment,
 	}))
 
     newChildren.forEach(child => eltDOM.appendChild(child))
+        // const fragment = new DocumentFragment();
+        // fragment.append(...newChildren);
+        // eltDOM.replaceChildren(fragment);
+
+        eltDOM.replaceChildren("")
+        newChildren.forEach(child => {
+            eltDOM.append(child)
+        });
+        // eltDOM.appendChild(fragment);
+        // eltDOM.append(fragment);
+
 
 	return eltDOM
 }

--- a/src/core.ts
+++ b/src/core.ts
@@ -173,7 +173,7 @@ export function invalidateUI(invalidatedElementIds?: string[]) {
 const DEFAULT_UPDATE_INTERVAL_MILLISECONDS = 14
 const INVALIDATED_ELEMENT_IDS: string[] = []
 
-const InvalidationHandler = async (eventInfo: Event) => {
+const invalidationHandler = async (eventInfo: Event) => {
 	let daemon: NodeJS.Timeout | undefined = undefined
 
 	// console.log(`UIInvalidated fired with detail: ${stringify((eventInfo as any).detail)}`)
@@ -207,7 +207,7 @@ export async function mountElement(element: UIElement, container: Element) {
 	// eslint-disable-next-line fp/no-let
 
 	// console.log(`Setting up UIInvalidated event listener on document`)
-	document.addEventListener('UIInvalidated', InvalidationHandler)
+	document.addEventListener('UIInvalidated', invalidationHandler)
 
 	container.replaceChildren(await renderAsync(element))
 }

--- a/src/core.ts
+++ b/src/core.ts
@@ -201,14 +201,8 @@ const invalidationHandler = async (eventInfo: Event) => {
 /** Convenience method to mount the entry point dom node of a client app */
 export async function mountElement(element: UIElement, container: Element) {
 	/** Library-specific DOM update/refresh interval */
-
-	// console.log(`Mounting element ${stringify(element)} on container ${container}...`)
-
-	// eslint-disable-next-line fp/no-let
-
-	// console.log(`Setting up UIInvalidated event listener on document`)
 	document.addEventListener('UIInvalidated', invalidationHandler)
-
+	
 	container.replaceChildren(await renderAsync(element))
 }
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -239,11 +239,10 @@ export async function updateChildrenAsync(eltDOM: DOMElement | DocumentFragment,
 		return updated
 	}))
 
-    newChildren.forEach(child => eltDOM.appendChild(child))
-        eltDOM.replaceChildren()
-        newChildren.forEach(child => {
-            eltDOM.append(child)
-        })
+	eltDOM.replaceChildren()
+	newChildren.forEach(child => {
+		eltDOM.append(child)
+	})
 	return eltDOM
 }
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -189,14 +189,12 @@ const InvalidationHandler = async (eventInfo: Event) => {
 		}
 		// eslint-disable-next-line fp/no-mutating-methods
 		const idsToProcess = INVALIDATED_ELEMENT_IDS.splice(0, INVALIDATED_ELEMENT_IDS.length)
-		const topmostElementIds = getApexElementIds(idsToProcess)
-		await Promise.all(topmostElementIds.map(id => {
+		await Promise.all(idsToProcess.map(id => {
 			// console.log(`Updating "${id}" dom element...`)
 			const elt = document.getElementById(id)
 			if (elt)
 				updateAsync(elt as DOMAugmented)
 		}))
-
 	}, DEFAULT_UPDATE_INTERVAL_MILLISECONDS)
 }
 
@@ -242,16 +240,10 @@ export async function updateChildrenAsync(eltDOM: DOMElement | DocumentFragment,
 	}))
 
     newChildren.forEach(child => eltDOM.appendChild(child))
-        // const fragment = new DocumentFragment();
-        // fragment.append(...newChildren);
-        // eltDOM.replaceChildren(fragment);
-
         eltDOM.replaceChildren()
         newChildren.forEach(child => {
             eltDOM.append(child)
         })
-        // eltDOM.appendChild(fragment);
-        // eltDOM.append(fragment);
 	return eltDOM
 }
 

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -71,13 +71,8 @@ export function setAttribute(element: DOMElement, attributeName: string, attribu
 				else {
 					// For string values, first set attribute using setAttribute, 
 					// for a few cases not handled properly by the assignment that follows
-					if (typeof effectiveVal === "string"){
+					if (typeof effectiveVal === "string" || effectiveVal === true){
 						element.setAttribute(attributeName, effectiveVal)
-					}
-
-					// We set boolean properties when they are true
-					if (effectiveVal === true){
-						element.setAttribute(attributeName, "")
 					}
 
 					// The <key> property on the element is set directly to <effectiveVal>. This approach works:

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -71,8 +71,14 @@ export function setAttribute(element: DOMElement, attributeName: string, attribu
 				else {
 					// For string values, first set attribute using setAttribute, 
 					// for a few cases not handled properly by the assignment that follows
-					if (typeof effectiveVal === "string")
-						element.setAttribute(attributeName, effectiveVal);
+					if (typeof effectiveVal === "string"){
+						element.setAttribute(attributeName, effectiveVal)
+					}
+
+					// We set boolean properties when they are true
+					if (effectiveVal === true){
+						element.setAttribute(attributeName, "");
+					}
 
 					// The <key> property on the element is set directly to <effectiveVal>. This approach works:
 					// for setting 'CHECKED', 'VALUE', and 'HTMLFOR' properties;

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -77,7 +77,7 @@ export function setAttribute(element: DOMElement, attributeName: string, attribu
 
 					// We set boolean properties when they are true
 					if (effectiveVal === true){
-						element.setAttribute(attributeName, "");
+						element.setAttribute(attributeName, "")
 					}
 
 					// The <key> property on the element is set directly to <effectiveVal>. This approach works:

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -71,7 +71,7 @@ export function setAttribute(element: DOMElement, attributeName: string, attribu
 				else {
 					// For string values, first set attribute using setAttribute, 
 					// for a few cases not handled properly by the assignment that follows
-					if (typeof effectiveVal === "string" || effectiveVal === true){
+					if (typeof effectiveVal === "string" || effectiveVal === true) {
 						element.setAttribute(attributeName, effectiveVal)
 					}
 
@@ -99,7 +99,9 @@ export function setAttribute(element: DOMElement, attributeName: string, attribu
  * @returns A text DOM element when passed a primitive value
  */
 export function createDOMShallow(eltUI: LeafElement): DOMElement | DocumentFragment | Text {
-	if (isEltProper(eltUI)) {
+	if (isIntrinsicElt(eltUI)) {
+		// if (typeof eltUI.type !== "string") { throw new Error("Blarg") }
+
 		const dom = svgTags.includes(eltUI.type.toUpperCase())
 			? document.createElementNS('http://www.w3.org/2000/svg', eltUI.type)
 			: eltUI.type === "" ? document.createDocumentFragment()

--- a/test/dom.test.tsx
+++ b/test/dom.test.tsx
@@ -171,6 +171,7 @@ describe("DOM MODULE", () => {
 
 		it("should set boolean/no-value attributes properly", async () => {
 			const input = document.createElement("input")
+			const option = document.createElement("option")
 			setAttribute(input, "type", "radio")
 
 			setAttribute(input, "DISABLED", "disabled")
@@ -201,6 +202,12 @@ describe("DOM MODULE", () => {
 			assert(!textArea.readOnly) // // Should fail since "readonly" not in the proper case
 			setAttribute(textArea, "readOnly", true)
 			assert(textArea.readOnly)
+
+			setAttribute(option, "selected", true)
+			assert(option.selected, "Option is selected")
+
+			setAttribute(option, "selected", false)
+			assert(!option.selected, "Option is not selected")
 		})
 	})
 

--- a/test/dom.test.tsx
+++ b/test/dom.test.tsx
@@ -175,7 +175,7 @@ describe("DOM MODULE", () => {
 			setAttribute(input, "type", "radio")
 
 			setAttribute(input, "DISABLED", "disabled")
-			assert.notStrictEqual(input.disabled, true) // Should fail since "DISABLED" not in the proper case
+			assert(input.disabled, "The input should be disabled") // Any non-empty string would count as the boolean being true
 
 			setAttribute(input, "disabled", "")
 			assert(input.disabled, "Boolean attribute removed by setting to empty string")
@@ -198,8 +198,7 @@ describe("DOM MODULE", () => {
 			assert(select.required)
 
 			const textArea = document.createElement("textarea")
-			setAttribute(textArea, "readonly", true)
-			assert(!textArea.readOnly) // // Should fail since "readonly" not in the proper case
+
 			setAttribute(textArea, "readOnly", true)
 			assert(textArea.readOnly)
 
@@ -207,7 +206,7 @@ describe("DOM MODULE", () => {
 			assert(option.selected, "Option is selected")
 
 			setAttribute(option, "selected", false)
-			assert(!option.selected, "Option is not selected")
+			assert.notStrictEqual(option.selected, true, "Option is not selected")
 		})
 	})
 


### PR DESCRIPTION
**Title**
fix: (https://github.com/Hypothesize/somatic.js/issues/87) [Rendering fixes](https://github.com/Hypothesize/somatic.js/issues/87)

**Merge message:**
Resolves https://github.com/Hypothesize/somatic.js/issues/87
- Added "SELECTED" as a boolean attribute that can be set to DOM elements
- Changed the way boolean attributes are set (using the `setAttribute` native function instead assigning a value through the `elem[attribute] = value` syntax)
- Turned the invalidation handler into a named function (instead of an anonymous function), so that assigning it to the "document" object several times (by mounting several elements, for instance) will not result in duplications (which would trigger several invalitions for every call to "invalidateUI")
- Modified the "updateChildrenAsync" function to replace the one-time appending of a fragment containing all the children, into an iteration of "append" calls. This helps with the display of <options> elements in <select> lists, on both Chrome and Firefox (before that, the last child would always be shown as selected, even when it's not)