### PR TITLE
PR: Create SVG title tags as SVG elements

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -159,7 +159,7 @@ export const svgTags = [
 
 	"TEXT",
 	"TEXTPATH",
-	//"TITLE",
+	"TITLE",
 	"TSPAN",
 
 	"UNKNOWN",


### PR DESCRIPTION
**Title**
feat: Create SVG title tags as SVG elements

**Merge message:**
Resolves https://github.com/Hypothesize/somatic.js/issues/92
Uncommented the tag "TITLE" from the list of SVG tags, so that tag elements are rendered as SVG elements.