### PR TITLE
PR - Fix: Update required npm version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-node@v1
         with:
-          node-version: 16
+          node-version: '>=20.x'
           registry-url: 'https://registry.npmjs.org'
         if: ${{ steps.release.outputs.release_created }}
          


### PR DESCRIPTION
Resolves #134 

**Merge message:**
Updated "release.yml" to make it install node at version ">=20.x" instead of 16, prior to running the publishing commands.